### PR TITLE
feat: Build of the crash reporter is now don in a docker container to ensure compatibility with met system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm
+
+# Install the curl and build-essential packages
+RUN apt-get update && \
+    apt-get install -y curl build-essential && \
+    apt-get clean
+    
+#Create volumen to mount the context dir in
+VOLUME ["/systemd-crash-reporter"]
+
+# Install Rust using rustup
+# RUN curl  --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# ENTRYPOINT ["systemd-crash-reporter/build.sh"]
+CMD ["/systemd-crash-reporter/build.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,5 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# ENTRYPOINT ["systemd-crash-reporter/build.sh"]
 CMD ["/systemd-crash-reporter/build.sh"]
 

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-DIR=$(dirname $0)
-PROJECT="$(pwd)/${DIR}"
+set -e
 
 rustup target add aarch64-unknown-linux-gnu
 
-sudo apt-get update > /dev/null
-sudo apt install -y gcc-aarch64-linux-gnu
+apt-get update > /dev/null
+apt install -y gcc-aarch64-linux-gnu
 
 CONFIG_FILE="$HOME/.cargo/config"
 
@@ -15,9 +14,10 @@ if ! grep -q "\[target.aarch64-unknown-linux-gnu\]" "$CONFIG_FILE" 2>/dev/null |
         echo '[target.aarch64-unknown-linux-gnu]'
         echo 'linker = "aarch64-linux-gnu-gcc"'
     } >> "$CONFIG_FILE"
-    ecjo
+    echo
 fi
 export TARGET_CC=aarch64-linux-gnu-gcc
 
+cd "/systemd-crash-reporter"
 cargo build --target aarch64-unknown-linux-gnu --release
 cargo build --release

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,9 @@ if ! grep -q "\[target.aarch64-unknown-linux-gnu\]" "$CONFIG_FILE" 2>/dev/null |
 fi
 export TARGET_CC=aarch64-linux-gnu-gcc
 
-cd "/systemd-crash-reporter"
+#get the script path
+DIR=$(dirname "$(realpath $0)")
+#go to the path of the script so cargo can find its config files
+cd "$DIR"
 cargo build --target aarch64-unknown-linux-gnu --release
 cargo build --release

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,11 @@ fn main() {
     ));
 
     // Extract environment variables provided by systemd
-    let unit = env::var("UNIT").unwrap_or_else(|_| "unknown".into());
-    let job_result = env::var("JOB_RESULT").unwrap_or_else(|_| "unknown".into());
-    let exit_code = env::var("EXIT_CODE").unwrap_or_else(|_| "unknown".into());
-    let exit_status = env::var("EXIT_STATUS").unwrap_or_else(|_| "unknown".into());
-    let invocation_id = env::var("INVOCATION_ID").unwrap_or_else(|_| "unknown".into());
+    let unit = env::var("MONITOR_UNIT").unwrap_or_else(|_| "unknown".into());
+    let job_result = env::var("MONITOR_SERVICE_RESULT").unwrap_or_else(|_| "unknown".into());
+    let exit_code = env::var("MONITOR_EXIT_CODE").unwrap_or_else(|_| "unknown".into());
+    let exit_status = env::var("MONITOR_EXIT_STATUS").unwrap_or_else(|_| "unknown".into());
+    let invocation_id = env::var("MONITOR_INVOCATION_ID").unwrap_or_else(|_| "unknown".into());
 
     // Get the machine's hostname
     let hostname = hostname::get()


### PR DESCRIPTION
- Add a container to build for an older version of GLIBC
    The build will now run in a debian:bookworm docker image, so that the binary built will use the GLIBC_2.36 instead of the current 2.38 version required.

- fix: change ENV variables read to the ones passed by the failed service
    According to the [systemd exec manual](https://www.freedesktop.org/software/systemd/man/252/systemd.exec.html), the variables passed to the service called onFailure are
```
MONITOR_UNIT
MONITOR_SERVICE_RESULT
MONITOR_EXIT_CODE
MONITOR_EXIT_STATUS
MONITOR_INVOCATION_ID

since version 251, we are running on version 252.
```
- feat: change hardcoded cd command
    change hardcoded `/systemd-crash-reporter` to dinamically get the path of the running script, so it can be run in or outside of the container

This commit requires approval of the PR: [Fix crash reporter issues #37 ](https://github.com/MeticulousHome/meticulous-machine/pull/37) on the `meticulous-machine` repo