### PR TITLE
Feat/get logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +152,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +191,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "crash-reporter"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "env_logger",
  "hostname 0.3.1",
  "openssl",
@@ -489,6 +519,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +823,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "object"
@@ -1719,6 +1782,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,7 +1829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -1749,6 +1847,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,5 @@ sentry = "0.37.0"
 sentry-log = "0.37.0"
 env_logger = "0.11"
 hostname = "0.3"
+chrono = "0.4"
 openssl = { version = "0.10.72", features = ["vendored"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update && \
 VOLUME ["/systemd-crash-reporter"]
 
 # Install Rust using rustup
-# RUN curl  --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 use std::env;
+use sentry::{protocol::Attachment, Scope, protocol::AttachmentType};
+use std::process::Command;
+use chrono::Utc;
 
 fn main() {
     let _guard = sentry::init((
@@ -16,7 +19,6 @@ fn main() {
     let exit_code = env::var("MONITOR_EXIT_CODE").unwrap_or_else(|_| "unknown".into());
     let exit_status = env::var("MONITOR_EXIT_STATUS").unwrap_or_else(|_| "unknown".into());
     let invocation_id = env::var("MONITOR_INVOCATION_ID").unwrap_or_else(|_| "unknown".into());
-
     // Get the machine's hostname
     let hostname = hostname::get()
         .map(|h| h.to_string_lossy().into_owned())
@@ -27,11 +29,47 @@ fn main() {
         "Service {} crashed (job_result: {}, exit_code: {}, exit_status: {}, invocation_id: {})",
         unit, job_result, exit_code, exit_status, invocation_id
     );
-    sentry::configure_scope(|scope| {
+
+    // Get 5 mins worth of logs from the crashed service, buffer it  
+    let output = Command::new("sh")
+                                                        .arg("-c")
+                                                        .arg(format!("journalctl --no-pager -u {} --since=\"5 minutes ago\"", unit))
+                                                        .output();
+    sentry::configure_scope(|scope: &mut Scope| {
+        let header = format!("\n =============== LAST 5 MINUTES OF LOGS FROM {} ===============\n\n", unit.to_ascii_uppercase()).into_bytes();
+        let data: Vec<u8> = match output {
+            Ok(cmd_out) => {
+                let logs = String::from_utf8_lossy(&cmd_out.stdout).to_ascii_lowercase();
+                // You can do extra logic here
+                println!("Got logs from {unit}:\n{logs}",);
+
+                // Convert the command output to lowercase and append it to a header
+                [header.as_slice(), logs.as_bytes()].concat()
+            }
+
+            Err(e) => {
+                // Log the error or do other side effects
+                eprintln!("Command failed: {}", e);
+
+                let error_msg = format!("Error getting logs from [{}]. e: {}", unit, e);
+                error_msg.into_bytes()
+            }
+        };
+
+        let date = Utc::now();
+        let filename = format!("{hostname} {unit} {date} crash logs.txt");
+        
+        let attachment: Attachment = Attachment {
+                                                        buffer: data,
+                                                        filename: filename,
+                                                        content_type: Some("text/plain".to_string()),
+                                                        ty: Some(AttachmentType::Attachment) };
+
         let mut map = std::collections::BTreeMap::new();
         map.insert(String::from("unit"), unit.clone().into());
         map.insert(String::from("hostname"), hostname.clone().into());
         scope.set_context("machine", sentry::protocol::Context::Other(map));
+        scope.add_attachment(attachment);
     });
 
     // Send to Sentry


### PR DESCRIPTION
feature: fetch last 5 minutes of logs for crashes
When the service is called, it looks for the last 5 minutes of logs of the crashed service to
see what could have gone wrong.
The logs are sent as an attachment file with the name
`{hostname} {crashed-unit} {date} crash logs.txt`

In case the journalctl command fails, that is reported also within the file

### Example of file on sentry
![image](https://github.com/user-attachments/assets/4cc28337-8776-4c98-998e-30503d6697ce)
