### PR TITLE
Add privacy-safe automatic crash diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,71 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
-dependencies = [
- "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,26 +87,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.41"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,29 +138,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -393,17 +285,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hostname"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
-dependencies = [
- "libc",
- "match_cfg",
- "winapi",
-]
-
-[[package]]
-name = "hostname"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
@@ -512,30 +393,6 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.63"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -684,40 +541,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a064218214dc6a10fbae5ec5fa888d80c45d611aba169222fc272072bf7aef6"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "199b7932d97e325aff3a7030e141eafe7f2c6268e1d1b24859b753a627f45254"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "js-sys"
@@ -758,12 +585,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-
-[[package]]
-name = "match_cfg"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "memchr"
@@ -819,15 +640,6 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-traits"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "object"
@@ -932,21 +744,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "portable-atomic"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "powerfmt"
@@ -1217,7 +1014,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "961990f9caa76476c481de130ada05614cd7f5aa70fb57c2142f0e09ad3fb2aa"
 dependencies = [
- "hostname 0.4.1",
+ "hostname",
  "libc",
  "os_info",
  "rustc_version",
@@ -1246,16 +1043,6 @@ checksum = "71ab5df4f3b64760508edfe0ba4290feab5acbbda7566a79d72673065888e5cc"
 dependencies = [
  "findshlibs",
  "once_cell",
- "sentry-core",
-]
-
-[[package]]
-name = "sentry-log"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693841da8dfb693af29105edfbea1d91348a13d23dd0a5d03761eedb9e450c46"
-dependencies = [
- "log",
  "sentry-core",
 ]
 
@@ -1624,12 +1411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,41 +1559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings 0.4.2",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,7 +1571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings 0.3.1",
+ "windows-strings",
  "windows-targets 0.53.0",
 ]
 
@@ -1843,15 +1589,6 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,12 +191,8 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "crash-reporter"
 version = "0.1.0"
 dependencies = [
- "chrono",
- "env_logger",
- "hostname 0.3.1",
  "openssl",
  "sentry",
- "sentry-log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,4 @@ edition = "2024"
 
 [dependencies]
 sentry = {version = "0.37.0", features = ["reqwest", "backtrace"]}
-sentry-log = "0.37.0"
-env_logger = "0.11"
-hostname = "0.3"
-chrono = "0.4"
 openssl = { version = "0.10.72", features = ["vendored"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn crash_message(unit: &str, job_result: &str, exit_code: &str, exit_status: &st
 
 fn main() {
     let _guard = sentry::init((
-        "https://7d92061929211477cb44b8071be63441@sentry.meticulousespresso.com/4",
+        "https://6f9403694443a82c06c958a8e6f40748@sentry.meticulousespresso.com/4",
         sentry::ClientOptions {
             release: sentry::release_name!(),
             send_default_pii: false,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,17 @@
-use chrono::Utc;
-use sentry::{
-    Client, Hub, Scope,
-    protocol::{Attachment, AttachmentType},
-    types::Dsn,
-};
+use sentry::Scope;
 use std::env;
 use std::fs;
-use std::process::Command;
-use std::sync::Arc;
+
+const BUILD_VERSION_PATH: &str = "/opt/image-build-version";
+const BUILD_DATE_PATH: &str = "/opt/ROOTFS_BUILD_DATE";
+const UNKNOWN: &str = "unknown";
+
+fn read_or_unknown(path: &str) -> String {
+    fs::read_to_string(path).unwrap_or_else(|cause| {
+        println!("Error {cause} while reading file at: {path}");
+        UNKNOWN.to_string()
+    })
+}
 
 fn main() {
     let _guard = sentry::init((
@@ -19,122 +23,27 @@ fn main() {
         },
     ));
 
-    let sc_dsn: Dsn = "https://295725e5bbfc9b3eb0413cafc1f6cea6@o4506723336060928.ingest.us.sentry.io/4509197049593856".parse().unwrap();
-
-    let mut sc_opts = sentry::ClientOptions {
-        debug: true,
-        release: sentry::release_name!(),
-        send_default_pii: false,
-        ..Default::default()
-    };
-    sc_opts.dsn = Some(sc_dsn);
-
-    sc_opts.transport = Some(Arc::new(sentry::transports::DefaultTransportFactory));
-
-    let secondary_client = Some(Arc::new(Client::from_config(sc_opts)));
-
-    // Extract environment variables provided by systemd
-    let unit = env::var("MONITOR_UNIT").unwrap_or_else(|_| "unknown".into());
-    let job_result = env::var("MONITOR_SERVICE_RESULT").unwrap_or_else(|_| "unknown".into());
-    let exit_code = env::var("MONITOR_EXIT_CODE").unwrap_or_else(|_| "unknown".into());
-    let exit_status = env::var("MONITOR_EXIT_STATUS").unwrap_or_else(|_| "unknown".into());
-    let invocation_id = env::var("MONITOR_INVOCATION_ID").unwrap_or_else(|_| "unknown".into());
-    // Get the machine's hostname
-    let hostname = hostname::get()
-        .map(|h| h.to_string_lossy().into_owned())
-        .unwrap_or_else(|_| "unknown".into());
-
-    // Construct an error message
-    let error_msg = format!(
-        "Service {} crashed (job_result: {}, exit_code: {}, exit_status: {}, invocation_id: {})",
-        unit, job_result, exit_code, exit_status, invocation_id
-    );
-
-    // Get 5 mins worth of logs from the crashed service, buffer it
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "journalctl --no-pager -u {} --since=\"5 minutes ago\"",
-            unit
-        ))
-        .output();
-    const BUILD_VERSION_PATH: &str = "/opt/image-build-version";
-    const BUILD_DATE_PATH: &str = "/opt/ROOTFS_BUILD_DATE";
-
-    let build_version = match fs::read_to_string(BUILD_VERSION_PATH) {
-        Ok(result) => result,
-        Err(cause) => {
-            println!(
-                "Error {} while reading file at: {}",
-                cause, BUILD_VERSION_PATH
-            );
-            String::from("unknown")
-        }
-    };
-
-    let build_date = match fs::read_to_string(BUILD_DATE_PATH) {
-        Ok(result) => result,
-
-        Err(cause) => {
-            println!(
-                "Error {} while reading file at: {}",
-                cause, BUILD_VERSION_PATH
-            );
-            String::from("unknown")
-        }
-    };
+    let unit = env::var("MONITOR_UNIT").unwrap_or_else(|_| UNKNOWN.to_string());
+    let job_result =
+        env::var("MONITOR_SERVICE_RESULT").unwrap_or_else(|_| UNKNOWN.to_string());
+    let exit_code = env::var("MONITOR_EXIT_CODE").unwrap_or_else(|_| UNKNOWN.to_string());
+    let exit_status =
+        env::var("MONITOR_EXIT_STATUS").unwrap_or_else(|_| UNKNOWN.to_string());
+    let build_version = read_or_unknown(BUILD_VERSION_PATH);
+    let build_date = read_or_unknown(BUILD_DATE_PATH);
 
     sentry::configure_scope(|scope: &mut Scope| {
-        let header = format!(
-            "\n =============== LAST 5 MINUTES OF LOGS FROM {} ===============\n\n",
-            unit.to_ascii_uppercase()
-        )
-        .into_bytes();
-        let data: Vec<u8> = match output {
-            Ok(cmd_out) => {
-                let logs = String::from_utf8_lossy(&cmd_out.stdout).to_ascii_lowercase();
-                println!("Got logs from {unit}\n",);
-
-                // Convert the command output to lowercase and append it to a header
-                [header.as_slice(), logs.as_bytes()].concat()
-            }
-
-            Err(e) => {
-                // Log the error or do other side effects
-                eprintln!("Command failed: {}", e);
-
-                let error_msg = format!("Error getting logs from [{}]. e: {}", unit, e);
-                error_msg.into_bytes()
-            }
-        };
-
-        let date = Utc::now();
-        let filename = format!("{hostname} {unit} {date} crash logs.txt");
-
-        let attachment: Attachment = Attachment {
-            buffer: data,
-            filename: filename,
-            content_type: Some("text/plain".to_string()),
-            ty: Some(AttachmentType::Attachment),
-        };
-
-        let mut map = std::collections::BTreeMap::new();
-        map.insert(String::from("unit"), unit.clone().into());
-        map.insert(String::from("hostname"), hostname.clone().into());
-        scope.set_context("machine", sentry::protocol::Context::Other(map));
-        scope.add_attachment(attachment);
-        scope.set_tag("hostname", hostname.clone());
+        scope.set_tag("unit", unit.clone());
+        scope.set_tag("job-result", job_result.clone());
+        scope.set_tag("exit-code", exit_code.clone());
+        scope.set_tag("exit-status", exit_status.clone());
         scope.set_tag("build-version", build_version.clone());
         scope.set_tag("build-date", build_date.clone());
     });
 
-    // Send to Sentry
-    sentry::capture_message(&error_msg, sentry::Level::Error);
-
-    Hub::with_active(|hub| {
-        hub.bind_client(secondary_client);
-        hub.capture_message(&error_msg, sentry::Level::Error);
-    });
-
-    println!("Captured error: {}", error_msg);
+    let error_message = format!(
+        "Service {unit} crashed (job_result: {job_result}, exit_code: {exit_code}, exit_status: {exit_status})"
+    );
+    sentry::capture_message(&error_message, sentry::Level::Error);
+    println!("Captured error: {error_message}");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use sentry::Scope;
 use std::env;
 use std::fs;
+use std::sync::Arc;
 
 const BUILD_VERSION_PATH: &str = "/opt/image-build-version";
 const BUILD_DATE_PATH: &str = "/opt/ROOTFS_BUILD_DATE";
 const UNKNOWN: &str = "unknown";
+const MAX_TAG_LENGTH: usize = 128;
 
 fn read_or_unknown(path: &str) -> String {
     fs::read_to_string(path).unwrap_or_else(|cause| {
@@ -13,26 +15,67 @@ fn read_or_unknown(path: &str) -> String {
     })
 }
 
+fn sanitize_technical_value(value: String) -> String {
+    let sanitized: String = value
+        .trim()
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '.' | '_' | '-' | '@' | ':' | '+')
+        })
+        .take(MAX_TAG_LENGTH)
+        .collect();
+
+    if sanitized.is_empty() {
+        UNKNOWN.to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn crash_message(unit: &str, job_result: &str, exit_code: &str, exit_status: &str) -> String {
+    format!(
+        "Service {unit} crashed (job_result: {job_result}, exit_code: {exit_code}, exit_status: {exit_status})"
+    )
+}
+
 fn main() {
     let _guard = sentry::init((
         "https://7d92061929211477cb44b8071be63441@sentry.meticulousespresso.com/4",
         sentry::ClientOptions {
             release: sentry::release_name!(),
             send_default_pii: false,
+            max_breadcrumbs: 0,
+            auto_session_tracking: false,
+            before_breadcrumb: Some(Arc::new(|_| None)),
+            before_send: Some(Arc::new(|mut event| {
+                event.server_name = None;
+                event.user = None;
+                event.request = None;
+                event.breadcrumbs.clear();
+                Some(event)
+            })),
             ..Default::default()
         },
     ));
 
-    let unit = env::var("MONITOR_UNIT").unwrap_or_else(|_| UNKNOWN.to_string());
-    let job_result =
-        env::var("MONITOR_SERVICE_RESULT").unwrap_or_else(|_| UNKNOWN.to_string());
-    let exit_code = env::var("MONITOR_EXIT_CODE").unwrap_or_else(|_| UNKNOWN.to_string());
-    let exit_status =
-        env::var("MONITOR_EXIT_STATUS").unwrap_or_else(|_| UNKNOWN.to_string());
-    let build_version = read_or_unknown(BUILD_VERSION_PATH);
-    let build_date = read_or_unknown(BUILD_DATE_PATH);
+    let unit = sanitize_technical_value(
+        env::var("MONITOR_UNIT").unwrap_or_else(|_| UNKNOWN.to_string()),
+    );
+    let job_result = sanitize_technical_value(
+        env::var("MONITOR_SERVICE_RESULT").unwrap_or_else(|_| UNKNOWN.to_string()),
+    );
+    let exit_code = sanitize_technical_value(
+        env::var("MONITOR_EXIT_CODE").unwrap_or_else(|_| UNKNOWN.to_string()),
+    );
+    let exit_status = sanitize_technical_value(
+        env::var("MONITOR_EXIT_STATUS").unwrap_or_else(|_| UNKNOWN.to_string()),
+    );
+    let build_version = sanitize_technical_value(read_or_unknown(BUILD_VERSION_PATH));
+    let build_date = sanitize_technical_value(read_or_unknown(BUILD_DATE_PATH));
 
     sentry::configure_scope(|scope: &mut Scope| {
+        scope.clear_breadcrumbs();
         scope.set_tag("unit", unit.clone());
         scope.set_tag("job-result", job_result.clone());
         scope.set_tag("exit-code", exit_code.clone());
@@ -41,9 +84,41 @@ fn main() {
         scope.set_tag("build-date", build_date.clone());
     });
 
-    let error_message = format!(
-        "Service {unit} crashed (job_result: {job_result}, exit_code: {exit_code}, exit_status: {exit_status})"
-    );
+    let error_message = crash_message(&unit, &job_result, &exit_code, &exit_status);
     sentry::capture_message(&error_message, sentry::Level::Error);
     println!("Captured error: {error_message}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn technical_values_are_bounded_and_remove_unapproved_characters() {
+        let value = format!(" service name\x00 with spaces / secret={} ", "x".repeat(200));
+        let sanitized = sanitize_technical_value(value);
+
+        assert!(sanitized.starts_with("servicenamewithspacessecret"));
+        assert!(sanitized.len() <= MAX_TAG_LENGTH);
+        for forbidden in [' ', '/', '=', '\0'] {
+            assert!(!sanitized.contains(forbidden));
+        }
+    }
+
+    #[test]
+    fn crash_message_contains_only_the_approved_fields() {
+        let message = crash_message(
+            "meticulous-backend.service",
+            "failed",
+            "exited",
+            "1",
+        );
+
+        assert_eq!(
+            message,
+            "Service meticulous-backend.service crashed (job_result: failed, exit_code: exited, exit_status: 1)"
+        );
+        assert!(!message.contains("hostname"));
+        assert!(!message.contains("invocation"));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,29 @@
 use sentry::Scope;
+use sentry::protocol::Event;
 use std::env;
 use std::fs;
+use std::process::Command;
 use std::sync::Arc;
 
 const BUILD_VERSION_PATH: &str = "/opt/image-build-version";
+const BUILD_CHANNEL_PATH: &str = "/opt/image-build-channel";
 const BUILD_DATE_PATH: &str = "/opt/ROOTFS_BUILD_DATE";
 const UNKNOWN: &str = "unknown";
 const MAX_TAG_LENGTH: usize = 128;
+const MICROSECONDS_PER_SECOND: u64 = 1_000_000;
+const ALLOWED_EVENT_TAGS: [&str; 11] = [
+    "unit",
+    "job-result",
+    "exit-code",
+    "exit-status",
+    "build-version",
+    "build-channel",
+    "build-date",
+    "component-version",
+    "restart-count",
+    "runtime-seconds",
+    "crash-reporter-version",
+];
 
 fn read_or_unknown(path: &str) -> String {
     fs::read_to_string(path).unwrap_or_else(|cause| {
@@ -21,7 +38,7 @@ fn sanitize_technical_value(value: String) -> String {
         .chars()
         .filter(|character| {
             character.is_ascii_alphanumeric()
-                || matches!(character, '.' | '_' | '-' | '@' | ':' | '+')
+                || matches!(character, '.' | '_' | '-' | '@' | ':' | '+' | '~')
         })
         .take(MAX_TAG_LENGTH)
         .collect();
@@ -33,6 +50,83 @@ fn sanitize_technical_value(value: String) -> String {
     }
 }
 
+fn sanitize_event(mut event: Event<'static>) -> Option<Event<'static>> {
+    event.server_name = None;
+    event.user = None;
+    event.request = None;
+    event.culprit = None;
+    event.transaction = None;
+    event.logentry = None;
+    event.logger = None;
+    event.modules.clear();
+    event.contexts.clear();
+    event.breadcrumbs.values.clear();
+    event.exception.values.clear();
+    event.stacktrace = None;
+    event.template = None;
+    event.threads.values.clear();
+    event.extra.clear();
+    event.debug_meta = Default::default();
+
+    event
+        .tags
+        .retain(|key, _| ALLOWED_EVENT_TAGS.contains(&key.as_str()));
+    for value in event.tags.values_mut() {
+        *value = sanitize_technical_value(std::mem::take(value));
+    }
+
+    Some(event)
+}
+
+fn command_value(program: &str, arguments: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(arguments).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = sanitize_technical_value(String::from_utf8(output.stdout).ok()?);
+    (value != UNKNOWN).then_some(value)
+}
+
+fn systemd_property(unit: &str, property: &str) -> Option<String> {
+    command_value(
+        "systemctl",
+        &["show", unit, "--property", property, "--value"],
+    )
+}
+
+fn component_package(unit: &str) -> Option<&'static str> {
+    match unit {
+        "meticulous-backend.service" => Some("meticulous-backend"),
+        "meticulous-dial.service" => Some("meticulous-dial"),
+        "meticulous-watcher.service" => Some("meticulous-watcher"),
+        "rauc-hawkbit-updater.service" => Some("rauc-hawkbit-updater"),
+        _ => None,
+    }
+}
+
+fn component_version(unit: &str) -> Option<String> {
+    let package = component_package(unit)?;
+    command_value(
+        "dpkg-query",
+        &["--show", "--showformat=${Version}", package],
+    )
+}
+
+fn runtime_seconds(start_micros: &str, exit_micros: &str) -> Option<String> {
+    let start_micros = start_micros.parse::<u64>().ok()?;
+    let exit_micros = exit_micros.parse::<u64>().ok()?;
+    let elapsed_micros = exit_micros.checked_sub(start_micros)?;
+
+    Some((elapsed_micros / MICROSECONDS_PER_SECOND).to_string())
+}
+
+fn service_runtime_seconds(unit: &str) -> Option<String> {
+    let start = systemd_property(unit, "ExecMainStartTimestampMonotonic")?;
+    let exit = systemd_property(unit, "ExecMainExitTimestampMonotonic")?;
+    runtime_seconds(&start, &exit)
+}
+
 fn crash_message(unit: &str, job_result: &str, exit_code: &str, exit_status: &str) -> String {
     format!(
         "Service {unit} crashed (job_result: {job_result}, exit_code: {exit_code}, exit_status: {exit_status})"
@@ -40,28 +134,28 @@ fn crash_message(unit: &str, job_result: &str, exit_code: &str, exit_status: &st
 }
 
 fn main() {
+    let build_version = sanitize_technical_value(read_or_unknown(BUILD_VERSION_PATH));
+    let build_channel = sanitize_technical_value(read_or_unknown(BUILD_CHANNEL_PATH));
+    let build_date = sanitize_technical_value(read_or_unknown(BUILD_DATE_PATH));
+    let release = format!("meticulous-linux@{build_version}");
+
     let _guard = sentry::init((
         "https://6f9403694443a82c06c958a8e6f40748@sentry.meticulousespresso.com/4",
         sentry::ClientOptions {
-            release: sentry::release_name!(),
+            release: Some(release.into()),
+            environment: Some(build_channel.clone().into()),
             send_default_pii: false,
+            default_integrations: false,
             max_breadcrumbs: 0,
             auto_session_tracking: false,
             before_breadcrumb: Some(Arc::new(|_| None)),
-            before_send: Some(Arc::new(|mut event| {
-                event.server_name = None;
-                event.user = None;
-                event.request = None;
-                event.breadcrumbs.clear();
-                Some(event)
-            })),
+            before_send: Some(Arc::new(sanitize_event)),
             ..Default::default()
         },
     ));
 
-    let unit = sanitize_technical_value(
-        env::var("MONITOR_UNIT").unwrap_or_else(|_| UNKNOWN.to_string()),
-    );
+    let unit =
+        sanitize_technical_value(env::var("MONITOR_UNIT").unwrap_or_else(|_| UNKNOWN.to_string()));
     let job_result = sanitize_technical_value(
         env::var("MONITOR_SERVICE_RESULT").unwrap_or_else(|_| UNKNOWN.to_string()),
     );
@@ -71,8 +165,9 @@ fn main() {
     let exit_status = sanitize_technical_value(
         env::var("MONITOR_EXIT_STATUS").unwrap_or_else(|_| UNKNOWN.to_string()),
     );
-    let build_version = sanitize_technical_value(read_or_unknown(BUILD_VERSION_PATH));
-    let build_date = sanitize_technical_value(read_or_unknown(BUILD_DATE_PATH));
+    let restart_count = systemd_property(&unit, "NRestarts");
+    let runtime_seconds = service_runtime_seconds(&unit);
+    let component_version = component_version(&unit);
 
     sentry::configure_scope(|scope: &mut Scope| {
         scope.clear_breadcrumbs();
@@ -81,7 +176,28 @@ fn main() {
         scope.set_tag("exit-code", exit_code.clone());
         scope.set_tag("exit-status", exit_status.clone());
         scope.set_tag("build-version", build_version.clone());
+        scope.set_tag("build-channel", build_channel.clone());
         scope.set_tag("build-date", build_date.clone());
+        scope.set_tag("crash-reporter-version", env!("CARGO_PKG_VERSION"));
+
+        if let Some(value) = &component_version {
+            scope.set_tag("component-version", value);
+        }
+        if let Some(value) = &restart_count {
+            scope.set_tag("restart-count", value);
+        }
+        if let Some(value) = &runtime_seconds {
+            scope.set_tag("runtime-seconds", value);
+        }
+
+        let fingerprint = [
+            "systemd-service-failure",
+            unit.as_str(),
+            job_result.as_str(),
+            exit_code.as_str(),
+            exit_status.as_str(),
+        ];
+        scope.set_fingerprint(Some(&fingerprint));
     });
 
     let error_message = crash_message(&unit, &job_result, &exit_code, &exit_status);
@@ -95,7 +211,10 @@ mod tests {
 
     #[test]
     fn technical_values_are_bounded_and_remove_unapproved_characters() {
-        let value = format!(" service name\x00 with spaces / secret={} ", "x".repeat(200));
+        let value = format!(
+            " service name\x00 with spaces / secret={} ",
+            "x".repeat(200)
+        );
         let sanitized = sanitize_technical_value(value);
 
         assert!(sanitized.starts_with("servicenamewithspacessecret"));
@@ -106,13 +225,51 @@ mod tests {
     }
 
     #[test]
-    fn crash_message_contains_only_the_approved_fields() {
-        let message = crash_message(
-            "meticulous-backend.service",
-            "failed",
-            "exited",
-            "1",
+    fn only_known_services_map_to_component_packages() {
+        assert_eq!(
+            component_package("meticulous-dial.service"),
+            Some("meticulous-dial")
         );
+        assert_eq!(
+            component_package("meticulous-backend.service"),
+            Some("meticulous-backend")
+        );
+        assert_eq!(component_package("customer-provided.service"), None);
+    }
+
+    #[test]
+    fn event_sanitizer_keeps_only_approved_diagnostic_tags() {
+        let mut event = Event {
+            server_name: Some("personal-hostname".into()),
+            ..Default::default()
+        };
+        event
+            .tags
+            .insert("unit".to_string(), "meticulous-dial.service".to_string());
+        event
+            .tags
+            .insert("hostname".to_string(), "personal-hostname".to_string());
+
+        let sanitized = sanitize_event(event).expect("diagnostic event should be retained");
+
+        assert_eq!(sanitized.server_name, None);
+        assert_eq!(
+            sanitized.tags.get("unit"),
+            Some(&"meticulous-dial.service".to_string())
+        );
+        assert!(!sanitized.tags.contains_key("hostname"));
+    }
+
+    #[test]
+    fn runtime_is_derived_from_monotonic_systemd_timestamps() {
+        assert_eq!(runtime_seconds("1000000", "4500000"), Some("3".to_string()));
+        assert_eq!(runtime_seconds("4500000", "1000000"), None);
+        assert_eq!(runtime_seconds("not-a-timestamp", "4500000"), None);
+    }
+
+    #[test]
+    fn crash_message_contains_only_the_approved_fields() {
+        let message = crash_message("meticulous-backend.service", "failed", "exited", "1");
 
         assert_eq!(
             message,


### PR DESCRIPTION
## Summary
- Send automatic Linux crash reports only to the self-hosted Sentry project using the newly issued client key.
- Remove the Cloud copy, hostname, invocation ID, journal attachment, machine context, breadcrumbs, and default PII.
- Report bounded systemd failure metadata plus image channel, component package version, restart count, and runtime before failure when available.
- Use `meticulous-linux@<build-version>` as the native Sentry release and the image channel as the environment.
- Group events with a stable fingerprint based on unit, service result, exit code, and exit status.
- Apply a fail-closed event sanitizer that retains only approved diagnostic tags and removes unexpected contexts, extras, stack data, and attachments.
- Do not enable or transmit coredumps, process memory, journal logs, arguments, variables, requests, or machine identifiers. Native stack traces remain a separate decision because the stable image does not install a coredump handler or symbolizer.

## Related PRs
- [Backend automatic events and config allowlist](https://github.com/MeticulousHome/meticulous-backend/pull/370)
- [Dial automatic events](https://github.com/MeticulousHome/meticulous-dial/pull/562)
- [ESP diagnostics](https://github.com/MeticulousHome/EspressoFirmware/pull/489)

## Validation
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` — 5 passed
- `cargo build --target aarch64-unknown-linux-gnu --release`
- Verified the release artifact is an ARM64 AArch64 ELF executable.