### PR TITLE
Add serial and privacy-safe system crash metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ version = "0.1.0"
 dependencies = [
  "openssl",
  "sentry",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -139,6 +140,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -276,6 +283,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hex"
@@ -532,6 +545,16 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1130,6 +1153,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,6 +1408,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "ureq"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-sentry = {version = "0.37.0", features = ["reqwest", "backtrace"]}
+sentry = { version = "0.37.0", features = ["reqwest", "backtrace"] }
 openssl = { version = "0.10.72", features = ["vendored"] }
+serde_yaml = "0.9.34"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::process::Command;
 use std::sync::Arc;
 
+mod system_metrics;
+
 const BUILD_VERSION_PATH: &str = "/opt/image-build-version";
 const BUILD_CHANNEL_PATH: &str = "/opt/image-build-channel";
 const BUILD_DATE_PATH: &str = "/opt/ROOTFS_BUILD_DATE";
@@ -74,7 +76,9 @@ fn sanitize_event(mut event: Event<'static>) -> Option<Event<'static>> {
     event.logentry = None;
     event.logger = None;
     event.modules.clear();
-    event.contexts.clear();
+    event.contexts.retain(|key, context| {
+        key == system_metrics::CONTEXT_NAME && system_metrics::sanitize(context)
+    });
     event.breadcrumbs.values.clear();
     event.exception.values.clear();
     event.stacktrace = None;
@@ -184,6 +188,7 @@ fn main() {
     let runtime_seconds = service_runtime_seconds(&unit);
     let component_version = component_version(&unit);
     let serial = machine_serial();
+    let system_metrics = system_metrics::collect(&unit);
 
     sentry::configure_scope(|scope: &mut Scope| {
         scope.clear_breadcrumbs();
@@ -208,6 +213,7 @@ fn main() {
         if let Some(value) = &serial {
             scope.set_tag("serial", value);
         }
+        scope.set_context(system_metrics::CONTEXT_NAME, system_metrics);
 
         let fingerprint = [
             "systemd-service-failure",
@@ -311,6 +317,34 @@ wifi:
         let sanitized = sanitize_event(event).expect("diagnostic event should be retained");
 
         assert_eq!(sanitized.tags.get("serial"), Some(&"M123-ABC".to_string()));
+    }
+
+    #[test]
+    fn event_sanitizer_retains_only_the_approved_system_metrics_context() {
+        let mut event = Event::default();
+        let mut metrics = std::collections::BTreeMap::new();
+        metrics.insert("memory-total-bytes".to_string(), 1024_u64.into());
+        metrics.insert("command-line".to_string(), "private argument".into());
+        event.contexts.insert(
+            system_metrics::CONTEXT_NAME.to_string(),
+            sentry::protocol::Context::Other(metrics),
+        );
+        event.contexts.insert(
+            "device".to_string(),
+            sentry::protocol::Context::Other(Default::default()),
+        );
+
+        let sanitized = sanitize_event(event).expect("diagnostic event should be retained");
+        assert_eq!(sanitized.contexts.len(), 1);
+        let sentry::protocol::Context::Other(metrics) = sanitized
+            .contexts
+            .get(system_metrics::CONTEXT_NAME)
+            .expect("approved metrics context should remain")
+        else {
+            panic!("system metrics should remain an arbitrary context");
+        };
+        assert!(metrics.contains_key("memory-total-bytes"));
+        assert!(!metrics.contains_key("command-line"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,11 @@ use std::sync::Arc;
 const BUILD_VERSION_PATH: &str = "/opt/image-build-version";
 const BUILD_CHANNEL_PATH: &str = "/opt/image-build-channel";
 const BUILD_DATE_PATH: &str = "/opt/ROOTFS_BUILD_DATE";
+const MACHINE_CONFIG_PATH: &str = "/meticulous-user/config/config.yml";
 const UNKNOWN: &str = "unknown";
 const MAX_TAG_LENGTH: usize = 128;
 const MICROSECONDS_PER_SECOND: u64 = 1_000_000;
-const ALLOWED_EVENT_TAGS: [&str; 11] = [
+const ALLOWED_EVENT_TAGS: [&str; 12] = [
     "unit",
     "job-result",
     "exit-code",
@@ -23,6 +24,7 @@ const ALLOWED_EVENT_TAGS: [&str; 11] = [
     "restart-count",
     "runtime-seconds",
     "crash-reporter-version",
+    "serial",
 ];
 
 fn read_or_unknown(path: &str) -> String {
@@ -48,6 +50,19 @@ fn sanitize_technical_value(value: String) -> String {
     } else {
         sanitized
     }
+}
+
+fn serial_from_config(config: &str) -> Option<String> {
+    let config: serde_yaml::Value = serde_yaml::from_str(config).ok()?;
+    let serial = config.get("system")?.get("serial")?.as_str()?;
+    let serial = sanitize_technical_value(serial.to_string());
+
+    (serial != UNKNOWN).then_some(serial)
+}
+
+fn machine_serial() -> Option<String> {
+    let config = fs::read_to_string(MACHINE_CONFIG_PATH).ok()?;
+    serial_from_config(&config)
 }
 
 fn sanitize_event(mut event: Event<'static>) -> Option<Event<'static>> {
@@ -168,6 +183,7 @@ fn main() {
     let restart_count = systemd_property(&unit, "NRestarts");
     let runtime_seconds = service_runtime_seconds(&unit);
     let component_version = component_version(&unit);
+    let serial = machine_serial();
 
     sentry::configure_scope(|scope: &mut Scope| {
         scope.clear_breadcrumbs();
@@ -188,6 +204,9 @@ fn main() {
         }
         if let Some(value) = &runtime_seconds {
             scope.set_tag("runtime-seconds", value);
+        }
+        if let Some(value) = &serial {
+            scope.set_tag("serial", value);
         }
 
         let fingerprint = [
@@ -258,6 +277,40 @@ mod tests {
             Some(&"meticulous-dial.service".to_string())
         );
         assert!(!sanitized.tags.contains_key("hostname"));
+    }
+
+    #[test]
+    fn serial_is_read_without_exposing_other_config_values() {
+        let config = r#"
+system:
+  serial: "M123-ABC"
+wifi:
+  KnownWifis:
+    - ssid: "Private Network"
+      password: "not-for-sentry"
+"#;
+
+        assert_eq!(serial_from_config(config), Some("M123-ABC".to_string()));
+    }
+
+    #[test]
+    fn serial_is_omitted_when_missing_invalid_or_not_a_string() {
+        assert_eq!(serial_from_config("system:\n  color: black\n"), None);
+        assert_eq!(serial_from_config("system: [invalid"), None);
+        assert_eq!(serial_from_config("system:\n  serial: 123\n"), None);
+        assert_eq!(serial_from_config("system:\n  serial: ' / = '\n"), None);
+    }
+
+    #[test]
+    fn event_sanitizer_retains_the_approved_serial_tag() {
+        let mut event = Event::default();
+        event
+            .tags
+            .insert("serial".to_string(), "M123-ABC".to_string());
+
+        let sanitized = sanitize_event(event).expect("diagnostic event should be retained");
+
+        assert_eq!(sanitized.tags.get("serial"), Some(&"M123-ABC".to_string()));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,7 +323,7 @@ wifi:
     fn event_sanitizer_retains_only_the_approved_system_metrics_context() {
         let mut event = Event::default();
         let mut metrics = std::collections::BTreeMap::new();
-        metrics.insert("memory-total-bytes".to_string(), 1024_u64.into());
+        metrics.insert("memory-total-mib".to_string(), 973_u64.into());
         metrics.insert("command-line".to_string(), "private argument".into());
         event.contexts.insert(
             system_metrics::CONTEXT_NAME.to_string(),
@@ -343,7 +343,7 @@ wifi:
         else {
             panic!("system metrics should remain an arbitrary context");
         };
-        assert!(metrics.contains_key("memory-total-bytes"));
+        assert!(metrics.contains_key("memory-total-mib"));
         assert!(!metrics.contains_key("command-line"));
     }
 

--- a/src/system_metrics.rs
+++ b/src/system_metrics.rs
@@ -1,0 +1,423 @@
+use sentry::protocol::Context;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use std::process::Command;
+
+pub const CONTEXT_NAME: &str = "system-metrics";
+
+const PROC_ROOT: &str = "/proc";
+const CGROUP_ROOT: &str = "/sys/fs/cgroup";
+const ROOT_DISK_PATH: &str = "/";
+const USER_DATA_DISK_PATH: &str = "/meticulous-user";
+const TOP_PROCESS_COUNT: usize = 3;
+const BYTES_PER_KIB: u64 = 1024;
+
+const ALLOWED_CONTEXT_FIELDS: [&str; 18] = [
+    "memory-total-bytes",
+    "memory-available-bytes",
+    "swap-total-bytes",
+    "swap-used-bytes",
+    "root-disk-total-bytes",
+    "root-disk-available-bytes",
+    "root-disk-used-percent",
+    "user-data-disk-total-bytes",
+    "user-data-disk-available-bytes",
+    "user-data-disk-used-percent",
+    "failed-service-memory-peak-bytes",
+    "failed-service-cpu-usage-nsec",
+    "top-process-1",
+    "top-process-1-rss-bytes",
+    "top-process-2",
+    "top-process-2-rss-bytes",
+    "top-process-3",
+    "top-process-3-rss-bytes",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ProcessMemory {
+    name: String,
+    rss_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MemorySnapshot {
+    total_bytes: u64,
+    available_bytes: u64,
+    swap_total_bytes: u64,
+    swap_used_bytes: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DiskSnapshot {
+    total_bytes: u64,
+    available_bytes: u64,
+    used_percent: u64,
+}
+
+fn sanitize_process_name(value: &str) -> Option<String> {
+    let sanitized: String = value
+        .trim()
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric()
+                || matches!(character, '.' | '_' | '-' | '@' | ':' | '+' | '~')
+        })
+        .take(64)
+        .collect();
+
+    (!sanitized.is_empty()).then_some(sanitized)
+}
+
+fn parse_kib_value(line: &str) -> Option<u64> {
+    line.split_whitespace()
+        .nth(1)?
+        .parse::<u64>()
+        .ok()?
+        .checked_mul(BYTES_PER_KIB)
+}
+
+fn parse_meminfo(contents: &str) -> Option<MemorySnapshot> {
+    let mut total_bytes = None;
+    let mut available_bytes = None;
+    let mut swap_total_bytes = None;
+    let mut swap_free_bytes = None;
+
+    for line in contents.lines() {
+        if line.starts_with("MemTotal:") {
+            total_bytes = parse_kib_value(line);
+        } else if line.starts_with("MemAvailable:") {
+            available_bytes = parse_kib_value(line);
+        } else if line.starts_with("SwapTotal:") {
+            swap_total_bytes = parse_kib_value(line);
+        } else if line.starts_with("SwapFree:") {
+            swap_free_bytes = parse_kib_value(line);
+        }
+    }
+
+    let swap_total_bytes = swap_total_bytes?;
+    Some(MemorySnapshot {
+        total_bytes: total_bytes?,
+        available_bytes: available_bytes?,
+        swap_total_bytes,
+        swap_used_bytes: swap_total_bytes.checked_sub(swap_free_bytes?)?,
+    })
+}
+
+fn memory_snapshot() -> Option<MemorySnapshot> {
+    parse_meminfo(&fs::read_to_string(Path::new(PROC_ROOT).join("meminfo")).ok()?)
+}
+
+fn parse_df_output(output: &str) -> Option<DiskSnapshot> {
+    let values = output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .last()?;
+    let mut values = values.split_whitespace();
+
+    Some(DiskSnapshot {
+        total_bytes: values.next()?.parse().ok()?,
+        available_bytes: values.next()?.parse().ok()?,
+        used_percent: values.next()?.trim_end_matches('%').parse().ok()?,
+    })
+}
+
+fn disk_snapshot(path: &str) -> Option<DiskSnapshot> {
+    let output = Command::new("df")
+        .args(["-B1", "--output=size,avail,pcent", "--", path])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    parse_df_output(&String::from_utf8(output.stdout).ok()?)
+}
+
+fn parse_process_rss(status: &str) -> Option<u64> {
+    status
+        .lines()
+        .find(|line| line.starts_with("VmRSS:"))
+        .and_then(parse_kib_value)
+}
+
+fn select_top_processes(processes: impl IntoIterator<Item = ProcessMemory>) -> Vec<ProcessMemory> {
+    let mut processes: Vec<ProcessMemory> = processes.into_iter().collect();
+    processes.sort_by(|left, right| {
+        right
+            .rss_bytes
+            .cmp(&left.rss_bytes)
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    processes.truncate(TOP_PROCESS_COUNT);
+    processes
+}
+
+fn top_processes() -> Vec<ProcessMemory> {
+    let Ok(entries) = fs::read_dir(PROC_ROOT) else {
+        return Vec::new();
+    };
+
+    let processes = entries.filter_map(|entry| {
+        let entry = entry.ok()?;
+        let pid = entry.file_name();
+        pid.to_str()?.parse::<u32>().ok()?;
+
+        let process_dir = entry.path();
+        let name = sanitize_process_name(&fs::read_to_string(process_dir.join("comm")).ok()?)?;
+        let rss_bytes = parse_process_rss(&fs::read_to_string(process_dir.join("status")).ok()?)?;
+        Some(ProcessMemory { name, rss_bytes })
+    });
+
+    select_top_processes(processes)
+}
+
+fn safe_cgroup_path(control_group: &str) -> Option<PathBuf> {
+    let relative = Path::new(control_group.trim()).strip_prefix("/").ok()?;
+    if relative.as_os_str().is_empty()
+        || !relative
+            .components()
+            .all(|component| matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+
+    Some(Path::new(CGROUP_ROOT).join(relative))
+}
+
+fn parse_unsigned(value: &str) -> Option<u64> {
+    value.trim().parse().ok()
+}
+
+fn failed_service_memory_peak(control_group: Option<&str>) -> Option<u64> {
+    let path = safe_cgroup_path(control_group?)?.join("memory.peak");
+    parse_unsigned(&fs::read_to_string(path).ok()?)
+}
+
+fn command_value(program: &str, arguments: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(arguments).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn systemd_property(unit: &str, property: &str) -> Option<String> {
+    command_value(
+        "systemctl",
+        &["show", unit, "--property", property, "--value"],
+    )
+}
+
+fn insert_disk_metrics(
+    map: &mut BTreeMap<String, sentry::protocol::Value>,
+    prefix: &str,
+    snapshot: DiskSnapshot,
+) {
+    map.insert(
+        format!("{prefix}-disk-total-bytes"),
+        snapshot.total_bytes.into(),
+    );
+    map.insert(
+        format!("{prefix}-disk-available-bytes"),
+        snapshot.available_bytes.into(),
+    );
+    map.insert(
+        format!("{prefix}-disk-used-percent"),
+        snapshot.used_percent.into(),
+    );
+}
+
+pub fn collect(unit: &str) -> Context {
+    let mut map = BTreeMap::new();
+
+    if let Some(memory) = memory_snapshot() {
+        map.insert("memory-total-bytes".to_string(), memory.total_bytes.into());
+        map.insert(
+            "memory-available-bytes".to_string(),
+            memory.available_bytes.into(),
+        );
+        map.insert(
+            "swap-total-bytes".to_string(),
+            memory.swap_total_bytes.into(),
+        );
+        map.insert("swap-used-bytes".to_string(), memory.swap_used_bytes.into());
+    }
+
+    if let Some(disk) = disk_snapshot(ROOT_DISK_PATH) {
+        insert_disk_metrics(&mut map, "root", disk);
+    }
+    if let Some(disk) = disk_snapshot(USER_DATA_DISK_PATH) {
+        insert_disk_metrics(&mut map, "user-data", disk);
+    }
+
+    let control_group = systemd_property(unit, "ControlGroup");
+    if let Some(memory_peak) = failed_service_memory_peak(control_group.as_deref()) {
+        map.insert(
+            "failed-service-memory-peak-bytes".to_string(),
+            memory_peak.into(),
+        );
+    }
+    if let Some(cpu_usage) =
+        systemd_property(unit, "CPUUsageNSec").and_then(|value| parse_unsigned(&value))
+    {
+        map.insert(
+            "failed-service-cpu-usage-nsec".to_string(),
+            cpu_usage.into(),
+        );
+    }
+
+    for (index, process) in top_processes().into_iter().enumerate() {
+        let position = index + 1;
+        map.insert(format!("top-process-{position}"), process.name.into());
+        map.insert(
+            format!("top-process-{position}-rss-bytes"),
+            process.rss_bytes.into(),
+        );
+    }
+
+    Context::Other(map)
+}
+
+pub fn sanitize(context: &mut Context) -> bool {
+    let Context::Other(values) = context else {
+        return false;
+    };
+
+    values.retain(|key, _| ALLOWED_CONTEXT_FIELDS.contains(&key.as_str()));
+    !values.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn meminfo_is_reduced_to_approved_numeric_metrics() {
+        let contents = "\
+MemTotal:        4096000 kB
+MemFree:          100000 kB
+MemAvailable:     512000 kB
+Buffers:           64000 kB
+SwapTotal:       1024000 kB
+SwapFree:         768000 kB
+";
+
+        assert_eq!(
+            parse_meminfo(contents),
+            Some(MemorySnapshot {
+                total_bytes: 4_194_304_000,
+                available_bytes: 524_288_000,
+                swap_total_bytes: 1_048_576_000,
+                swap_used_bytes: 262_144_000,
+            })
+        );
+    }
+
+    #[test]
+    fn df_output_is_reduced_to_capacity_values() {
+        let output = "\
+1B-blocks       Avail Use%
+31138512896 11800000000  63%
+";
+
+        assert_eq!(
+            parse_df_output(output),
+            Some(DiskSnapshot {
+                total_bytes: 31_138_512_896,
+                available_bytes: 11_800_000_000,
+                used_percent: 63,
+            })
+        );
+    }
+
+    #[test]
+    fn process_rss_parser_ignores_other_process_status_fields() {
+        let status = "\
+Name:\tmeticulous-dial
+State:\tS (sleeping)
+VmSize:\t1200000 kB
+VmRSS:\t812000 kB
+";
+
+        assert_eq!(parse_process_rss(status), Some(831_488_000));
+    }
+
+    #[test]
+    fn process_names_are_bounded_and_remove_unapproved_characters() {
+        assert_eq!(
+            sanitize_process_name(" WebKit Web/Process --customer=value "),
+            Some("WebKitWebProcess--customervalue".to_string())
+        );
+        assert_eq!(sanitize_process_name(" / = "), None);
+    }
+
+    #[test]
+    fn top_processes_are_sorted_and_limited() {
+        let selected = select_top_processes([
+            ProcessMemory {
+                name: "watcher".to_string(),
+                rss_bytes: 90,
+            },
+            ProcessMemory {
+                name: "dial".to_string(),
+                rss_bytes: 800,
+            },
+            ProcessMemory {
+                name: "backend".to_string(),
+                rss_bytes: 300,
+            },
+            ProcessMemory {
+                name: "journald".to_string(),
+                rss_bytes: 100,
+            },
+        ]);
+
+        assert_eq!(
+            selected,
+            vec![
+                ProcessMemory {
+                    name: "dial".to_string(),
+                    rss_bytes: 800,
+                },
+                ProcessMemory {
+                    name: "backend".to_string(),
+                    rss_bytes: 300,
+                },
+                ProcessMemory {
+                    name: "journald".to_string(),
+                    rss_bytes: 100,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn cgroup_path_cannot_escape_the_cgroup_root() {
+        assert_eq!(
+            safe_cgroup_path("/system.slice/meticulous-backend.service"),
+            Some(PathBuf::from(
+                "/sys/fs/cgroup/system.slice/meticulous-backend.service"
+            ))
+        );
+        assert_eq!(safe_cgroup_path("/../../meticulous-user"), None);
+        assert_eq!(safe_cgroup_path("/"), None);
+    }
+
+    #[test]
+    fn context_sanitizer_keeps_only_approved_metrics() {
+        let mut values = BTreeMap::new();
+        values.insert("memory-total-bytes".to_string(), 1024_u64.into());
+        values.insert("command-line".to_string(), "private argument".into());
+        let mut context = Context::Other(values);
+
+        assert!(sanitize(&mut context));
+        let Context::Other(values) = context else {
+            panic!("approved context should remain an arbitrary context");
+        };
+        assert!(values.contains_key("memory-total-bytes"));
+        assert!(!values.contains_key("command-line"));
+    }
+}

--- a/src/system_metrics.rs
+++ b/src/system_metrics.rs
@@ -12,26 +12,28 @@ const ROOT_DISK_PATH: &str = "/";
 const USER_DATA_DISK_PATH: &str = "/meticulous-user";
 const TOP_PROCESS_COUNT: usize = 3;
 const BYTES_PER_KIB: u64 = 1024;
+const BYTES_PER_MIB: u64 = 1024 * 1024;
+const NANOSECONDS_PER_TENTH_SECOND: u64 = 100_000_000;
 
 const ALLOWED_CONTEXT_FIELDS: [&str; 18] = [
-    "memory-total-bytes",
-    "memory-available-bytes",
-    "swap-total-bytes",
-    "swap-used-bytes",
-    "root-disk-total-bytes",
-    "root-disk-available-bytes",
+    "memory-total-mib",
+    "memory-available-mib",
+    "swap-total-mib",
+    "swap-used-mib",
+    "root-disk-total-mib",
+    "root-disk-available-mib",
     "root-disk-used-percent",
-    "user-data-disk-total-bytes",
-    "user-data-disk-available-bytes",
+    "user-data-disk-total-mib",
+    "user-data-disk-available-mib",
     "user-data-disk-used-percent",
-    "failed-service-memory-peak-bytes",
-    "failed-service-cpu-usage-nsec",
+    "failed-service-memory-peak-mib",
+    "failed-service-cpu-usage-seconds",
     "top-process-1",
-    "top-process-1-rss-bytes",
+    "top-process-1-rss-mib",
     "top-process-2",
-    "top-process-2-rss-bytes",
+    "top-process-2-rss-mib",
     "top-process-3",
-    "top-process-3-rss-bytes",
+    "top-process-3-rss-mib",
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -189,6 +191,16 @@ fn parse_unsigned(value: &str) -> Option<u64> {
     value.trim().parse().ok()
 }
 
+fn bytes_to_mib(value: u64) -> u64 {
+    value.saturating_add(BYTES_PER_MIB / 2) / BYTES_PER_MIB
+}
+
+fn nanoseconds_to_seconds(value: u64) -> f64 {
+    let tenths =
+        value.saturating_add(NANOSECONDS_PER_TENTH_SECOND / 2) / NANOSECONDS_PER_TENTH_SECOND;
+    tenths as f64 / 10.0
+}
+
 fn failed_service_memory_peak(control_group: Option<&str>) -> Option<u64> {
     let path = safe_cgroup_path(control_group?)?.join("memory.peak");
     parse_unsigned(&fs::read_to_string(path).ok()?)
@@ -217,12 +229,12 @@ fn insert_disk_metrics(
     snapshot: DiskSnapshot,
 ) {
     map.insert(
-        format!("{prefix}-disk-total-bytes"),
-        snapshot.total_bytes.into(),
+        format!("{prefix}-disk-total-mib"),
+        bytes_to_mib(snapshot.total_bytes).into(),
     );
     map.insert(
-        format!("{prefix}-disk-available-bytes"),
-        snapshot.available_bytes.into(),
+        format!("{prefix}-disk-available-mib"),
+        bytes_to_mib(snapshot.available_bytes).into(),
     );
     map.insert(
         format!("{prefix}-disk-used-percent"),
@@ -234,16 +246,22 @@ pub fn collect(unit: &str) -> Context {
     let mut map = BTreeMap::new();
 
     if let Some(memory) = memory_snapshot() {
-        map.insert("memory-total-bytes".to_string(), memory.total_bytes.into());
         map.insert(
-            "memory-available-bytes".to_string(),
-            memory.available_bytes.into(),
+            "memory-total-mib".to_string(),
+            bytes_to_mib(memory.total_bytes).into(),
         );
         map.insert(
-            "swap-total-bytes".to_string(),
-            memory.swap_total_bytes.into(),
+            "memory-available-mib".to_string(),
+            bytes_to_mib(memory.available_bytes).into(),
         );
-        map.insert("swap-used-bytes".to_string(), memory.swap_used_bytes.into());
+        map.insert(
+            "swap-total-mib".to_string(),
+            bytes_to_mib(memory.swap_total_bytes).into(),
+        );
+        map.insert(
+            "swap-used-mib".to_string(),
+            bytes_to_mib(memory.swap_used_bytes).into(),
+        );
     }
 
     if let Some(disk) = disk_snapshot(ROOT_DISK_PATH) {
@@ -256,16 +274,16 @@ pub fn collect(unit: &str) -> Context {
     let control_group = systemd_property(unit, "ControlGroup");
     if let Some(memory_peak) = failed_service_memory_peak(control_group.as_deref()) {
         map.insert(
-            "failed-service-memory-peak-bytes".to_string(),
-            memory_peak.into(),
+            "failed-service-memory-peak-mib".to_string(),
+            bytes_to_mib(memory_peak).into(),
         );
     }
     if let Some(cpu_usage) =
         systemd_property(unit, "CPUUsageNSec").and_then(|value| parse_unsigned(&value))
     {
         map.insert(
-            "failed-service-cpu-usage-nsec".to_string(),
-            cpu_usage.into(),
+            "failed-service-cpu-usage-seconds".to_string(),
+            nanoseconds_to_seconds(cpu_usage).into(),
         );
     }
 
@@ -273,8 +291,8 @@ pub fn collect(unit: &str) -> Context {
         let position = index + 1;
         map.insert(format!("top-process-{position}"), process.name.into());
         map.insert(
-            format!("top-process-{position}-rss-bytes"),
-            process.rss_bytes.into(),
+            format!("top-process-{position}-rss-mib"),
+            bytes_to_mib(process.rss_bytes).into(),
         );
     }
 
@@ -409,7 +427,7 @@ VmRSS:\t812000 kB
     #[test]
     fn context_sanitizer_keeps_only_approved_metrics() {
         let mut values = BTreeMap::new();
-        values.insert("memory-total-bytes".to_string(), 1024_u64.into());
+        values.insert("memory-total-mib".to_string(), 973_u64.into());
         values.insert("command-line".to_string(), "private argument".into());
         let mut context = Context::Other(values);
 
@@ -417,7 +435,14 @@ VmRSS:\t812000 kB
         let Context::Other(values) = context else {
             panic!("approved context should remain an arbitrary context");
         };
-        assert!(values.contains_key("memory-total-bytes"));
+        assert!(values.contains_key("memory-total-mib"));
         assert!(!values.contains_key("command-line"));
+    }
+
+    #[test]
+    fn telemetry_units_are_human_readable_and_rounded() {
+        assert_eq!(bytes_to_mib(199_491_584), 190);
+        assert_eq!(bytes_to_mib(286_396_416), 273);
+        assert_eq!(nanoseconds_to_seconds(1_556_872_315_000), 1556.9);
     }
 }


### PR DESCRIPTION
## Summary

- add the approved machine serial as a filterable Sentry tag without restoring hostname or `machine_name`
- add an allowlisted `system-metrics` context containing RAM and swap capacity, fixed-filesystem capacity, failed-service CPU usage, and the three surviving processes with the highest RSS
- report memory, disk, and process RSS as rounded whole MiB values, and CPU usage as seconds rounded to one decimal, so events are readable without post-processing raw bytes or nanoseconds
- include the failed service's cgroup v2 `memory.peak` only when it remains readable at report time; otherwise omit it
- keep the event privacy boundary: no logs, command lines, arguments, paths, users, PIDs, breadcrumbs, or unapproved Sentry contexts are sent

## Validation

- `cargo fmt --check`
- `cargo test --locked` (17 passed)
- `cargo check --locked --target aarch64-unknown-linux-gnu`
- ARM64 release build completed successfully and was verified as an AArch64 ELF artifact
- refreshed `origin/stable` and confirmed it is the branch ancestor before publication
- installed the exact ARM64 release artifact on a stable test machine and ran synthetic `pr9-test` and `pr9-readable-units-test` reports directly, without restarting services
- confirmed the target exposes the failed service's cgroup v2 `memory.peak` and systemd `CPUUsageNSec`; backend, Dial, and watcher remained active after both tests